### PR TITLE
chore: remove @efiop from maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,5 +41,4 @@ about:
 extra:
   recipe-maintainers:
     - daavoo
-    - efiop
     - shcheklein


### PR DESCRIPTION
Remove `efiop` from this feedstock's recipe maintainer list because I am stepping away from conda-forge maintenance.

The other listed maintainer or maintainers remain unchanged. This does not change the package, recipe requirements, or build output.

Validation: the diff contains exactly one deleted maintainer entry and passes `git diff --check`.
